### PR TITLE
Fixes for #12, #11 and #7

### DIFF
--- a/install-custom.sh
+++ b/install-custom.sh
@@ -174,9 +174,15 @@ curl -o "${TMPFILE}" "${NETBEANS_URI}"
 echo "Unpacking Netbeans archive..."
 ${SUDO_COMMAND}unzip "${TMPFILE}" -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
 
-${SUDO_COMMAND}mv "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans"
-${SUDO_COMMAND}ln -s "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/bin/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS/netbeans"
-${SUDO_COMMAND}cp "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/nb/netbeans.icns" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
+echo "Finishing touches on NetBeans ${NETBEANS_VERSION}.app..."
+${SUDO_COMMAND}mv "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/netbeans" \
+                  "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans"
+
+${SUDO_COMMAND}ln -s "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/bin/netbeans" \
+                     "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS/netbeans"
+
+${SUDO_COMMAND}cp "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/nb/netbeans.icns" \
+                  "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
 
 echo "Cleaning up..."
 rm "${TMPFILE}"

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -167,7 +167,7 @@ ${SUDO_COMMAND}mv "${TMPFILE}" \
 
 curl ${NETBEANS_URI} > temp.zip
 ${SUDO_COMMAND}unzip temp.zip -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
-${SUDO_COMMAND}mv "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans {$NETBEANS_VERSION}.app/Contents/Resources/NetBeans"
+${SUDO_COMMAND}mv "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans"
 rm temp.zip
 ${SUDO_COMMAND}ln -s "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/bin/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS/netbeans"
 ${SUDO_COMMAND}cp "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/nb/netbeans.icns" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -28,6 +28,8 @@ show_help() {
     echo "        Please note that the default installation path requires root permissions."
     echo "        You need to specify a different path using --install-dir to change this."
     echo
+    echo "    -h | --help"
+    echo "        Show this help."
 }
 
 # the trailing space is required
@@ -57,6 +59,10 @@ case $key in
     shift
     shift
     ;;    
+    -h | --help)
+    show_help
+    exit
+    ;;
     -*)
     echo "Unknown option: $1"
     show_help

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -106,6 +106,13 @@ case $key in
 esac
 done
 
+if [ ! -z "${SUDO_COMMAND}" ]
+then
+    echo "The script might ask for a password. This is because sudo is used to"
+    echo "gain root permissions to create the software package"
+    echo
+fi
+
 # check if target directory already exists and allow the user to delete
 # it by using the --force | -f command line option
 if [ -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/" ]; then

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -32,6 +32,10 @@ show_help() {
     echo "        Displays extra information during a run. Namely a more detailed progress "
     echo "        from curl for the download and the list of extracted files from the archive."
     echo
+    echo "    -f | --force"
+    echo "        Allows the script to remove an existing package before installing. Otherwise"
+    echo "        the script will refuse to install the package if it already exists."
+    echo
     echo "    -h | --help"
     echo "        Show this help."
 }
@@ -41,6 +45,7 @@ SUDO_COMMAND='sudo '
 INSTALL_DIR='/Applications'
 PROGRESSBAR='--progress-bar'
 QUIETUNZIP='-q'
+FORCE=0
 
 while [[ $# -gt 0 ]]
 do
@@ -70,6 +75,10 @@ case $key in
     unset QUIETUNZIP
     shift
     ;;
+    -f|--force)
+    FORCE=1
+    shift
+    ;;
     -h | --help)
     show_help
     exit
@@ -96,6 +105,31 @@ case $key in
     ;;
 esac
 done
+
+# check if target directory already exists and allow the user to delete
+# it by using the --force | -f command line option
+if [ -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/" ]; then
+
+    if [ "${FORCE}" -eq 0 ]
+    then
+        echo "Refusing to overwrite the existing app ${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app."
+        echo "Please delete the old app first before trying to create a new one"
+        echo "or specify -f|--force as an option to have the script delete it for you."
+        exit 1
+    else
+        echo "Deleting ${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app..."
+
+        read -r -p "Are you sure? [y/N] " response
+        case "${response}" in [yY][eE][sS]|[yY])
+            ${SUDO_COMMAND}rm -r "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/"
+            ;;
+        *)
+            echo "Exiting without creating the app."
+            exit 0
+            ;;
+        esac
+    fi
+fi
 
 ${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS"
 ${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources"

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+# these need to be updated for new versions.
+NETBEANS_VERSION='9'
+NETBEANS_URI="http://apache.mirrors.pair.com/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-bin.zip"
+
 show_help() {
     echo "./install-custom.sh [--install-dir /Applications] [--netbeans-uri http://some.apache.netbeans.mirror] [--non-root-install]"
 }
 
 INSTALL_DIR='/Applications'
-NETBEANS_VERSION='9'
-NETBEANS_URI="http://apache.mirrors.pair.com/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-bin.zip"
 SUDO_COMMAND='sudo'
 
 while [[ $# -gt 0 ]]

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -138,6 +138,9 @@ if [ -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/" ]; then
     fi
 fi
 
+# TODO: There should be a check if we can write to the target folder
+# but I have no idea how to do that at the moment ;)
+
 ${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS"
 ${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources"
 

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -106,10 +106,10 @@ Contributor(s):
 <plist version="1.0">
   <dict>
     <key>CFBundleName</key>
-    <string>NetBeans "$NETBEANS_VERSION"</string>
+    <string>NetBeans ${NETBEANS_VERSION}</string>
 
     <key>CFBundleVersion</key>
-    <string>"$NETBEANS_VERSION"</string>
+    <string>${NETBEANS_VERSION}</string>
 
     <key>CFBundleExecutable</key>
     <string>netbeans</string>
@@ -118,10 +118,10 @@ Contributor(s):
     <string>APPL</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>"$NETBEANS_VERSION"</string>
+    <string>${NETBEANS_VERSION}</string>
 
     <key>CFBundleIdentifier</key>
-    <string>org.netbeans.ide.baseide."$NETBEANS_VERSION"</string>
+    <string>org.netbeans.ide.baseide.${NETBEANS_VERSION}</string>
 
     <key>CFBundleSignature</key>
     <string>NETB</string>
@@ -156,9 +156,9 @@ Contributor(s):
 </plist>
 EOT
 
-curl $NETBEANS_URI > temp.zip
-${SUDO_COMMAND}unzip temp.zip -d "${INSTALL_DIR}/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/"
-${SUDO_COMMAND}mv "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/netbeans" "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans"
+curl ${NETBEANS_URI} > temp.zip
+${SUDO_COMMAND}unzip temp.zip -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
+${SUDO_COMMAND}mv "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans {$NETBEANS_VERSION}.app/Contents/Resources/NetBeans"
 rm temp.zip
-${SUDO_COMMAND}ln -s "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans/bin/netbeans" "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/MacOS/netbeans"
-${SUDO_COMMAND}cp "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans/nb/netbeans.icns" "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/"
+${SUDO_COMMAND}ln -s "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/bin/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS/netbeans"
+${SUDO_COMMAND}cp "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/nb/netbeans.icns" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -5,7 +5,29 @@ NETBEANS_VERSION='9'
 NETBEANS_URI="http://apache.mirrors.pair.com/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-bin.zip"
 
 show_help() {
-    echo "./install-custom.sh [--install-dir /Applications] [--netbeans-uri http://some.apache.netbeans.mirror] [--non-root-install]"
+    echo "./install-custom.sh [options]"
+    echo
+    echo "Available Options:"
+    echo "    -d | --install-dir <path>"
+    echo "        (Default: /Applications):"
+    echo "        Change the directory where the app is going to be installed in."
+    echo
+    echo "     -v|--netbeans-version <version>"
+    echo "         (Default: ${NETBEANS_VERSION})"
+    echo "         Creates an application with the corresponding version number."
+    echo "         Please note that this does not change the downloaded version,"
+    echo "         but just affects the created package name."
+    echo
+    echo "     -u | --netbeans-uri <URI>"
+    echo "         (Default: ${NETBEANS_URI})"
+    echo "         Change the download URI from where to get the Netbeans package."
+    echo "         You can use a mirror closer to you to get higher download speeds."
+    echo
+    echo "    -n | --non-root-install"
+    echo "        Do not install as root using sudo."
+    echo "        Please note that the default installation path requires root permissions."
+    echo "        You need to specify a different path using --install-dir to change this."
+    echo
 }
 
 # the trailing space is required

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -61,7 +61,13 @@ done
 ${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS"
 ${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources"
 
-cat >> "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Info.plist" << EOT
+# while you can use " | sudo tee" to write to a file as a superuser,
+# the easier method is to just create a temporary file and 
+# move it using sudo (this also avoids the content being printed on stdout)
+
+TMPFILE=`mktemp`
+
+cat >> "${TMPFILE}" << EOT
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
@@ -145,7 +151,7 @@ Contributor(s):
 		</array>
 	</dict>
     </array>
-    
+
     <key>NSHighResolutionCapable</key>
     <true/>
 
@@ -155,6 +161,9 @@ Contributor(s):
   </dict>
 </plist>
 EOT
+
+${SUDO_COMMAND}mv "${TMPFILE}" \
+                  "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Info.plist"
 
 curl ${NETBEANS_URI} > temp.zip
 ${SUDO_COMMAND}unzip temp.zip -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -165,9 +165,20 @@ EOT
 ${SUDO_COMMAND}mv "${TMPFILE}" \
                   "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Info.plist"
 
-curl ${NETBEANS_URI} > temp.zip
-${SUDO_COMMAND}unzip temp.zip -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
+# don't use temp.zip, but a file created with mktmp
+TMPFILE=`mktemp`
+
+echo "Downloading ${NETBEANS_URI}..."
+curl -o "${TMPFILE}" "${NETBEANS_URI}"
+
+echo "Unpacking Netbeans archive..."
+${SUDO_COMMAND}unzip "${TMPFILE}" -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
+
 ${SUDO_COMMAND}mv "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans"
-rm temp.zip
 ${SUDO_COMMAND}ln -s "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/bin/netbeans" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS/netbeans"
 ${SUDO_COMMAND}cp "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/NetBeans/nb/netbeans.icns" "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
+
+echo "Cleaning up..."
+rm "${TMPFILE}"
+
+echo "All done."

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -8,8 +8,9 @@ show_help() {
     echo "./install-custom.sh [--install-dir /Applications] [--netbeans-uri http://some.apache.netbeans.mirror] [--non-root-install]"
 }
 
+# the trailing space is required
+SUDO_COMMAND='sudo '
 INSTALL_DIR='/Applications'
-SUDO_COMMAND='sudo'
 
 while [[ $# -gt 0 ]]
 do
@@ -57,8 +58,8 @@ case $key in
 esac
 done
 
-eval "${SUDO_COMMAND}" mkdir -p "\"${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS\""
-eval "${SUDO_COMMAND}" mkdir -p "\"${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources\""
+${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/MacOS"
+${SUDO_COMMAND}mkdir -p "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources"
 
 cat >> "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Info.plist" << EOT
 <?xml version="1.0" encoding="UTF-8"?>
@@ -156,8 +157,8 @@ Contributor(s):
 EOT
 
 curl $NETBEANS_URI > temp.zip
-eval "${SUDO_COMMAND+set} unzip temp.zip -d \"${INSTALL_DIR}/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/\""
-eval "${SUDO_COMMAND+set} mv \"$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/netbeans\" \"$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans\""
+${SUDO_COMMAND}unzip temp.zip -d "${INSTALL_DIR}/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/"
+${SUDO_COMMAND}mv "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/netbeans" "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans"
 rm temp.zip
-eval "${SUDO_COMMAND+set} ln -s \"$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans/bin/netbeans\" \"$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/MacOS/netbeans\""
-eval "${SUDO_COMMAND+set} cp \"$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans/nb/netbeans.icns\" \"$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/\""
+${SUDO_COMMAND}ln -s "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans/bin/netbeans" "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/MacOS/netbeans"
+${SUDO_COMMAND}cp "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/NetBeans/nb/netbeans.icns" "$INSTALL_DIR/NetBeans/NetBeans $NETBEANS_VERSION.app/Contents/Resources/"

--- a/install-custom.sh
+++ b/install-custom.sh
@@ -28,6 +28,10 @@ show_help() {
     echo "        Please note that the default installation path requires root permissions."
     echo "        You need to specify a different path using --install-dir to change this."
     echo
+    echo "    --verbose"
+    echo "        Displays extra information during a run. Namely a more detailed progress "
+    echo "        from curl for the download and the list of extracted files from the archive."
+    echo
     echo "    -h | --help"
     echo "        Show this help."
 }
@@ -35,6 +39,8 @@ show_help() {
 # the trailing space is required
 SUDO_COMMAND='sudo '
 INSTALL_DIR='/Applications'
+PROGRESSBAR='--progress-bar'
+QUIETUNZIP='-q'
 
 while [[ $# -gt 0 ]]
 do
@@ -59,6 +65,11 @@ case $key in
     shift
     shift
     ;;    
+    --verbose)
+    unset PROGRESSBAR
+    unset QUIETUNZIP
+    shift
+    ;;
     -h | --help)
     show_help
     exit
@@ -197,10 +208,10 @@ ${SUDO_COMMAND}mv "${TMPFILE}" \
 TMPFILE=`mktemp`
 
 echo "Downloading ${NETBEANS_URI}..."
-curl -o "${TMPFILE}" "${NETBEANS_URI}"
+curl ${PROGRESSBAR} -o "${TMPFILE}" "${NETBEANS_URI}"
 
 echo "Unpacking Netbeans archive..."
-${SUDO_COMMAND}unzip "${TMPFILE}" -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
+${SUDO_COMMAND}unzip ${QUIETUNZIP} "${TMPFILE}" -d "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/"
 
 echo "Finishing touches on NetBeans ${NETBEANS_VERSION}.app..."
 ${SUDO_COMMAND}mv "${INSTALL_DIR}/NetBeans/NetBeans ${NETBEANS_VERSION}.app/Contents/Resources/netbeans" \


### PR DESCRIPTION
I fixed the permission problem with the Info.plist file by writing it to a temporary file and then `sudo mv` it to the final location.

I also changed the way the `sudo` command is called and got rid of `eval` that was used before.

In addition, there's now a check if the install directory exists, so it doesn't overwrite the target or run into problems with moving / linking files. This can be overridden by _-f | --force_ which deletes the target after a confirmation prompt.

`curl` and `unzip` are now a little more quiet, unless you specify _--verbose_

If `sudo` is used, the user gets a small explanation why he might be asked for a password.

There's other smaller changes like a more detailed help (_-h | --help_) and a temporary filename instead of "temp.zip".